### PR TITLE
Fix space on django tag

### DIFF
--- a/template/format_index_html.py
+++ b/template/format_index_html.py
@@ -6,7 +6,7 @@ file = 'templates/index.html'
 with open(file, "r+") as f:
     s = f.read()
     f.seek(0)
-    f.write("{ % load staticfiles % }\n" + s)
+    f.write("{% load staticfiles %}\n" + s)
 
 for i, line in enumerate(fileinput.input(file, inplace=1)):
     sys.stdout.write(line.replace('href=//', "href={% static '"))


### PR DESCRIPTION
Spaces on tag throw `TemplateSyntaxError: Invalid block tag on line 2: 'static'. Did you forget to register or load this tag?`

